### PR TITLE
Capitalize Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-An action that runs PyCodeStyle over python code. If there are errors found in the Python code then the action will fail.
+An action that runs PyCodeStyle over Python code. If there are errors found in the Python code then the action will fail.
 
 Example workflow:
 


### PR DESCRIPTION
Capitalize Python here, since it's capitalized in the next sentence.